### PR TITLE
wiredtiger lost some changes with concurrent modification to one entry

### DIFF
--- a/servers/slapd/back-wt/key.c
+++ b/servers/slapd/back-wt/key.c
@@ -136,10 +136,12 @@ wt_key_change(
 		if ( rc == WT_NOTFOUND ) rc = 0;
 	}
 	if( rc ) {
-		Debug( LDAP_DEBUG_ANY,
-			   LDAP_XSTRING(wt_key_change)
-			   ": error: %s (%d)\n",
-			   wiredtiger_strerror(rc), rc, 0);
+		if ( rc != WT_ROLLBACK ) {
+			Debug( LDAP_DEBUG_ANY,
+				   LDAP_XSTRING(wt_key_change)
+				   ": error: %s (%d)\n",
+				   wiredtiger_strerror(rc), rc, 0);
+		}
 		return rc;
 	}
 


### PR DESCRIPTION
When some clients modify one entry with multi values at same time, some changes may be lost.
Because reading entry and writing modification is not atomic in wt_modify().

So, I changed begin_transcation() to "snapshot mode".
If the modification conflicts, that operation fails with WT_ROLLBACK.
So it does rollback_transaction() and do that modification again with a new transaction. 