### PR TITLE
back-wt: SLAP_DBFLAG_CLEAN is always set.

### DIFF
--- a/servers/slapd/back-wt/init.c
+++ b/servers/slapd/back-wt/init.c
@@ -83,6 +83,9 @@ wt_db_open( BackendDB *be, ConfigReply *cr )
 		return -1;
 	}
 
+	/* back-wt is always clean */
+	be->be_flags |= SLAP_DBFLAG_CLEAN;
+	
 	/* Open and create database */
 	rc = wiredtiger_open(wi->wi_home, NULL,
 						 wi->wi_config, &wi->wi_conn);


### PR DESCRIPTION
#10 fix back-wt  by set SLAP_DBFLAG_CLEAN.